### PR TITLE
Update docker-compose & dockerfiles to control startup order

### DIFF
--- a/Dockerfile-haproxy
+++ b/Dockerfile-haproxy
@@ -1,4 +1,8 @@
 FROM haproxy:2.0.7
 MAINTAINER Antonio Musarra <antonio.musarra@gmail.com>
 
+RUN apt-get update && apt-get install -y curl
+ADD https://raw.githubusercontent.com/lgdd/wait-for-liferay/master/wait-for-liferay.sh /
+RUN chmod a+x /wait-for-liferay.sh
+
 COPY ./haproxy/configs/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg

--- a/Dockerfile-liferay
+++ b/Dockerfile-liferay
@@ -1,6 +1,9 @@
 FROM liferay/portal:7.2.0-ga1
 MAINTAINER Antonio Musarra <antonio.musarra@gmail.com>
 
+ADD --chown=liferay:liferay https://raw.githubusercontent.com/lgdd/wait-for-liferay/master/wait-for-liferay.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/wait-for-liferay.sh
+
 COPY --chown=liferay:liferay liferay/configs/portal-ext.properties $LIFERAY_HOME/
 COPY --chown=liferay:liferay liferay/osgi/configs/* $LIFERAY_HOME/osgi/configs/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     depends_on:
       - liferay-portal-node-1
       - liferay-portal-node-2
-    entrypoint: /wait-for-liferay.sh liferay-portal-node-2:8080 -- /docker-entrypoint.sh haproxy -d -f /usr/local/etc/haproxy/haproxy.cfg
+    entrypoint: /wait-for-liferay.sh -q liferay-portal-node-2:8080 -- /docker-entrypoint.sh haproxy -d -f /usr/local/etc/haproxy/haproxy.cfg
   liferay-portal-node-1:
     build:
       context: .
@@ -44,7 +44,7 @@ services:
       - postgres
       - es-node-1
       - es-node-2
-    entrypoint: /usr/local/bin/wait-for-liferay.sh liferay-portal-node-1:8080 -- /usr/local/bin/liferay_entrypoint.sh
+    entrypoint: /usr/local/bin/wait-for-liferay.sh -q liferay-portal-node-1:8080 -- /usr/local/bin/liferay_entrypoint.sh
   postgres:
     image: postgres
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     depends_on:
       - liferay-portal-node-1
       - liferay-portal-node-2
+    entrypoint: /wait-for-liferay.sh liferay-portal-node-2:8080 -- /docker-entrypoint.sh haproxy -d -f /usr/local/etc/haproxy/haproxy.cfg
   liferay-portal-node-1:
     build:
       context: .
@@ -43,6 +44,7 @@ services:
       - postgres
       - es-node-1
       - es-node-2
+    entrypoint: /usr/local/bin/wait-for-liferay.sh liferay-portal-node-1:8080 -- /usr/local/bin/liferay_entrypoint.sh
   postgres:
     image: postgres
     environment:


### PR DESCRIPTION
Hi @amusarra,

I pushed a script to check Liferay instance availability [here](https://github.com/lgdd/wait-for-liferay) in order to control order startup with docker containers.
So I updated `Dockerfile-haproxy` & `Dockerfile-liferay` to include this script. I also updated `docker-compose.yml` to override entrypoints and control the startup order of docker containers following your `README.md` which indicates this order: `liferay-portal-node-1`, `liferay-portal-node-2` and `haproxy`. Now, we should be able to simply run `docker-compose up --build -d`.

Thanks,
Best,